### PR TITLE
更新至 AFNetworking ~2.0  版本、重命名LCHttpClient 至 AVSNSHttpClient

### DIFF
--- a/LeanCloudSocial.podspec
+++ b/LeanCloudSocial.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "LeanCloudSocial"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "LeanCloud iOS Social SDK for mobile backend."
   s.homepage     = "https://leancloud.cn"
   s.license        = { :type => "Commercial", :text => "© Copyright 2015 LeanCloud, Inc. See https://leancloud.cn/terms.html" }

--- a/LeanCloudSocial.podspec
+++ b/LeanCloudSocial.podspec
@@ -7,11 +7,11 @@ Pod::Spec.new do |s|
   s.license        = { :type => "Commercial", :text => "© Copyright 2015 LeanCloud, Inc. See https://leancloud.cn/terms.html" }
   s.author             = { "LeanCloud" => "support@leancloud.cn" }
   s.documentation_url = "https://leancloud.cn/docs/sns.html"
-  s.platform     = :ios, "5.1.1"
+  s.platform     = :ios, "6.0"
   s.source       = { :git => "https://github.com/leancloud/leancloud-social-ios.git", :tag => s.version.to_s }
   s.source_files  = "LeanCloudSocial/**/*.{h,m}"
   s.public_header_files = "LeanCloudSocial/**/*.h"
   s.dependency "AVOSCloud", "~> 3.1"
-  s.dependency "AFNetworking", "~> 1.0"
+  s.dependency "AFNetworking", "~> 2.0"
 end
 

--- a/LeanCloudSocial.podspec
+++ b/LeanCloudSocial.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "LeanCloudSocial"
-  s.version      = "0.0.2"
+  s.version      = "0.0.3"
   s.summary      = "LeanCloud iOS Social SDK for mobile backend."
   s.homepage     = "https://leancloud.cn"
   s.license        = { :type => "Commercial", :text => "© Copyright 2015 LeanCloud, Inc. See https://leancloud.cn/terms.html" }

--- a/LeanCloudSocial.xcodeproj/project.pbxproj
+++ b/LeanCloudSocial.xcodeproj/project.pbxproj
@@ -36,8 +36,8 @@
 		70A6A1671B661BA6005C2D21 /* AVUser+SNS.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A6A1561B661BA6005C2D21 /* AVUser+SNS.m */; };
 		70A6A1681B661BA6005C2D21 /* AVWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A6A1571B661BA6005C2D21 /* AVWebViewController.h */; };
 		70A6A1691B661BA6005C2D21 /* AVWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A6A1581B661BA6005C2D21 /* AVWebViewController.m */; };
-		70A6A16A1B661BA6005C2D21 /* LCHttpClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A6A1591B661BA6005C2D21 /* LCHttpClient.h */; };
-		70A6A16B1B661BA6005C2D21 /* LCHttpClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A6A15A1B661BA6005C2D21 /* LCHttpClient.m */; };
+		70A6A16A1B661BA6005C2D21 /* AVSNSHttpClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A6A1591B661BA6005C2D21 /* AVSNSHttpClient.h */; };
+		70A6A16B1B661BA6005C2D21 /* AVSNSHttpClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A6A15A1B661BA6005C2D21 /* AVSNSHttpClient.m */; };
 		70A6A16C1B661BA6005C2D21 /* NSURL+AVAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A6A15B1B661BA6005C2D21 /* NSURL+AVAdditions.h */; };
 		70A6A16D1B661BA6005C2D21 /* NSURL+AVAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A6A15C1B661BA6005C2D21 /* NSURL+AVAdditions.m */; };
 		FD22A6DD2631A2D9293AAC93 /* libPods-LeanCloudSocial.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C904EA0C993C8E9F1446505C /* libPods-LeanCloudSocial.a */; };
@@ -74,8 +74,8 @@
 		70A6A1561B661BA6005C2D21 /* AVUser+SNS.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AVUser+SNS.m"; sourceTree = "<group>"; };
 		70A6A1571B661BA6005C2D21 /* AVWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVWebViewController.h; sourceTree = "<group>"; };
 		70A6A1581B661BA6005C2D21 /* AVWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVWebViewController.m; sourceTree = "<group>"; };
-		70A6A1591B661BA6005C2D21 /* LCHttpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LCHttpClient.h; sourceTree = "<group>"; };
-		70A6A15A1B661BA6005C2D21 /* LCHttpClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCHttpClient.m; sourceTree = "<group>"; };
+		70A6A1591B661BA6005C2D21 /* AVSNSHttpClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVSNSHttpClient.h; sourceTree = "<group>"; };
+		70A6A15A1B661BA6005C2D21 /* AVSNSHttpClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AVSNSHttpClient.m; sourceTree = "<group>"; };
 		70A6A15B1B661BA6005C2D21 /* NSURL+AVAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURL+AVAdditions.h"; sourceTree = "<group>"; };
 		70A6A15C1B661BA6005C2D21 /* NSURL+AVAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURL+AVAdditions.m"; sourceTree = "<group>"; };
 		C904EA0C993C8E9F1446505C /* libPods-LeanCloudSocial.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-LeanCloudSocial.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -137,8 +137,8 @@
 				70A6A1561B661BA6005C2D21 /* AVUser+SNS.m */,
 				70A6A1571B661BA6005C2D21 /* AVWebViewController.h */,
 				70A6A1581B661BA6005C2D21 /* AVWebViewController.m */,
-				70A6A1591B661BA6005C2D21 /* LCHttpClient.h */,
-				70A6A15A1B661BA6005C2D21 /* LCHttpClient.m */,
+				70A6A1591B661BA6005C2D21 /* AVSNSHttpClient.h */,
+				70A6A15A1B661BA6005C2D21 /* AVSNSHttpClient.m */,
 				70A6A15B1B661BA6005C2D21 /* NSURL+AVAdditions.h */,
 				70A6A15C1B661BA6005C2D21 /* NSURL+AVAdditions.m */,
 				5CC504441B0EC5B8004D0CB1 /* Supporting Files */,
@@ -198,7 +198,7 @@
 				70A6A1641B661BA6005C2D21 /* AVSNSWebViewController.h in Headers */,
 				70A6A16C1B661BA6005C2D21 /* NSURL+AVAdditions.h in Headers */,
 				70A6A15E1B661BA6005C2D21 /* AVOSCloudSNS.h in Headers */,
-				70A6A16A1B661BA6005C2D21 /* LCHttpClient.h in Headers */,
+				70A6A16A1B661BA6005C2D21 /* AVSNSHttpClient.h in Headers */,
 				70A6A1681B661BA6005C2D21 /* AVWebViewController.h in Headers */,
 				70A6A1601B661BA6005C2D21 /* AVOSCloudSNSUtils.h in Headers */,
 				70A6A1661B661BA6005C2D21 /* AVUser+SNS.h in Headers */,
@@ -362,7 +362,7 @@
 				70A6A1631B661BA6005C2D21 /* AVSNSLoginViewController.m in Sources */,
 				70A6A1691B661BA6005C2D21 /* AVWebViewController.m in Sources */,
 				70A6A1651B661BA6005C2D21 /* AVSNSWebViewController.m in Sources */,
-				70A6A16B1B661BA6005C2D21 /* LCHttpClient.m in Sources */,
+				70A6A16B1B661BA6005C2D21 /* AVSNSHttpClient.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LeanCloudSocial.xcodeproj/project.pbxproj
+++ b/LeanCloudSocial.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 				);
 				INFOPLIST_FILE = LeanCloudSocial/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -509,7 +509,7 @@
 				);
 				INFOPLIST_FILE = LeanCloudSocial/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/LeanCloudSocial/AVOSCloudSNS_.h
+++ b/LeanCloudSocial/AVOSCloudSNS_.h
@@ -14,7 +14,7 @@
 
 @interface AVOSCloudSNS ()
 +(NSMutableDictionary*)ssoConfigs;
-+(AFHTTPClient*)client;
++ (AFHTTPRequestOperationManager *)requestManager;
 
 +(void)onSuccess:(AVOSCloudSNSType)type withToken:(NSString*)token andExpires:(NSString*)expires andUid:(NSString*)uid;
 +(void)onSuccess:(AVOSCloudSNSType)type withParams:(NSDictionary*)info;

--- a/LeanCloudSocial/AVSNSHttpClient.h
+++ b/LeanCloudSocial/AVSNSHttpClient.h
@@ -9,9 +9,9 @@
 #import <Foundation/Foundation.h>
 #import <AVOSCloud/AVOSCloud.h>
 
-@interface LCHttpClient : NSObject
+@interface AVSNSHttpClient : NSObject
 
-+(LCHttpClient *)sharedInstance;
++(AVSNSHttpClient *)sharedInstance;
 
 -(void)postObject:(NSString *)path
    withParameters:(NSDictionary *)parameters

--- a/LeanCloudSocial/AVSNSHttpClient.m
+++ b/LeanCloudSocial/AVSNSHttpClient.m
@@ -6,21 +6,21 @@
 //  Copyright (c) 2015 LeanCloud. All rights reserved.
 //
 
-#import "LCHttpClient.h"
+#import "AVSNSHttpClient.h"
 #import "AVOSCloudSNSUtils.h"
 
-@interface LCHttpClient ()
+@interface AVSNSHttpClient ()
 
 @property (nonatomic, strong) NSURL *baseURL;
 @property (nonatomic, strong) NSOperationQueue *operationQueue;
 
 @end
 
-@implementation LCHttpClient
+@implementation AVSNSHttpClient
 
-+ (LCHttpClient*)sharedInstance {
++ (AVSNSHttpClient*)sharedInstance {
     static dispatch_once_t once;
-    static LCHttpClient * sharedInstance;
+    static AVSNSHttpClient * sharedInstance;
     dispatch_once(&once, ^{
         sharedInstance = [[self alloc] init];
         sharedInstance.baseURL = [NSURL URLWithString:@"https://api.leancloud.cn/1.1/"];

--- a/LeanCloudSocial/AVSNSLoginViewController.m
+++ b/LeanCloudSocial/AVSNSLoginViewController.m
@@ -101,7 +101,7 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
                                   @"display":@"mobile",
                                   };
             
-            NSURLRequest *req=[[AVOSCloudSNS client] requestWithMethod:@"GET" path:@"https://open.weibo.cn/oauth2/authorize" parameters:param];
+            NSURLRequest *req = [[AFHTTPRequestSerializer serializer] requestWithMethod:@"GET" URLString:@"https://open.weibo.cn/oauth2/authorize" parameters:param error:nil];
             
             [self.webView loadRequest:req];
         }
@@ -110,7 +110,7 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
             
         case AVOSCloudSNSQQ:
         {
-            NSDictionary *param=@{
+            NSDictionary *params=@{
                                   @"client_id":self.appkey,
                                   @"redirect_uri":self.redirect_uri,
                                   @"display":@"mobile",
@@ -120,8 +120,7 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
                                   @"ucheck":@1,
                                   @"fall_to_wv":@1
                                   };
-            
-            NSURLRequest *req=[[AVOSCloudSNS client] requestWithMethod:@"GET" path:@"https://openmobile.qq.com/oauth2.0/m_show" parameters:param];
+            NSURLRequest *req = [[AFHTTPRequestSerializer serializer] requestWithMethod:@"GET" URLString:@"https://openmobile.qq.com/oauth2.0/m_show" parameters:params error:nil];
             
             [self.webView loadRequest:req];
         }
@@ -169,7 +168,7 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
             return;
     }
     
-    [[AVOSCloudSNS client] postPath:url parameters:param success:^(AFHTTPRequestOperation *operation, id responseObject) {
+    [[AVOSCloudSNS requestManager] POST:url parameters:param success:^(AFHTTPRequestOperation *operation, id responseObject) {
         NSDictionary *info=[NSJSONSerialization JSONObjectWithData:responseObject options:NSJSONReadingAllowFragments error:nil];
         
         NSString *token=info[@"access_token"];
@@ -187,9 +186,8 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
             [AVOSCloudSNS onFail:self.type withError:error];
         }
     } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
-        [AVOSCloudSNS onFail:self.type withError:error];
+        
     }];
-    
 }
 
 -(BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType{
@@ -207,7 +205,7 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
         
         if(hasCode){
             //avos返回用户信息
-            [[AVOSCloudSNS client] getPath:url parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
+            [[AVOSCloudSNS requestManager] GET:url parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
                 NSDictionary *info=[NSJSONSerialization JSONObjectWithData:responseObject options:NSJSONReadingAllowFragments error:nil];
                 info=info[@"user"];
                 if (info) {
@@ -220,8 +218,6 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
             } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
                 [AVOSCloudSNS onFail:self.type withError:error];
             }];
-            
-            
             return NO;
         }else if ([url rangeOfString:@"access_denied"].length>0) {
             //用户取消
@@ -257,7 +253,7 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
             [self getAccessToken:code];
             return NO;
         }else if (token && self.type==AVOSCloudSNSQQ){
-            [[AVOSCloudSNS client] getPath:[NSString stringWithFormat:@"https://graph.qq.com/oauth2.0/me?access_token=%@",token] parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
+            [[AVOSCloudSNS requestManager] GET:[NSString stringWithFormat:@"https://graph.qq.com/oauth2.0/me?access_token=%@",token] parameters:nil success:^(AFHTTPRequestOperation *operation, id responseObject) {
                 NSString *string=[[NSString alloc] initWithBytes:[responseObject bytes] length:[responseObject length] encoding:NSUTF8StringEncoding];
                 NSDictionary *ret= [AVOSCloudSNSUtils unserializeJSONP:string];
                 NSString *openid=ret[@"openid"];
@@ -265,7 +261,6 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
             } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
                 [AVOSCloudSNS onFail:AVOSCloudSNSQQ withError:error];
             }];
-            
         }
     }else{
 //        NSLog(@"Open :%@",url);

--- a/LeanCloudSocial/AVUser+SNS.m
+++ b/LeanCloudSocial/AVUser+SNS.m
@@ -264,12 +264,7 @@ NSString *const AVOSCloudSNSPlatformWeiXin = @"weixin";
 //            username = mzv62gzwrwzqtz75rv51kzye6;
             
             user = [self user];
-//            user = [AVObject objectWithClassName:@"_User" dictionary:object];
-            user.objectId = object[@"objectId"];
-            user.sessionToken = object[@"sessionToken"];
-            user.username = object[@"username"];
-            // createdAt 不能赋值 readOnly
-//            user.createdAt = object[@"createdAt"];
+            [user objectFromDictionary:object];
             if(!object[@"authData"]){
                 [user setObject:dict[@"authData"] forKey:@"authData"];
             }

--- a/LeanCloudSocial/AVUser+SNS.m
+++ b/LeanCloudSocial/AVUser+SNS.m
@@ -257,8 +257,19 @@ NSString *const AVOSCloudSNSPlatformWeiXin = @"weixin";
     [[AVSNSHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
         AVUser * user = nil;
         if (!error) {
+            // 第一次会返回
+//            objectId = 55b8b76400b066e34529d4a6;
+//            sessionToken = fzs03y5g7hr4r22iikhv2babe;
+//            createdAt = "2015-07-29T11:33:03.642Z";
+//            username = mzv62gzwrwzqtz75rv51kzye6;
+            
             user = [self user];
-            [AVOSCloudSNSUtils copyDictionary:object toObject:user];
+//            user = [AVObject objectWithClassName:@"_User" dictionary:object];
+            user.objectId = object[@"objectId"];
+            user.sessionToken = object[@"sessionToken"];
+            user.username = object[@"username"];
+            // createdAt 不能赋值 readOnly
+//            user.createdAt = object[@"createdAt"];
             if(!object[@"authData"]){
                 [user setObject:dict[@"authData"] forKey:@"authData"];
             }

--- a/LeanCloudSocial/AVUser+SNS.m
+++ b/LeanCloudSocial/AVUser+SNS.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 AVOS. All rights reserved.
 //
 #import "AVUser+SNS.h"
-#import "LCHttpClient.h"
+#import "AVSNSHttpClient.h"
 #import "AVOSCloudSNSUtils.h"
 #import "AVOSCloudSNS.h"
 
@@ -147,7 +147,7 @@ NSString *const AVOSCloudSNSPlatformWeiXin = @"weixin";
                                          [[self class] nameOfPlatform:[authData[@"platform"] intValue]]:
                                              [[self class] authDataFromSNSResult:authData]
                                          }};
-            [[LCHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
+            [[AVSNSHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
                 if (error == nil)
                 {
                     [AVOSCloudSNSUtils copyDictionary:object toObject:ws];
@@ -194,7 +194,7 @@ NSString *const AVOSCloudSNSPlatformWeiXin = @"weixin";
     }else{
         //这个是新产生的用户, 需要在服务器注册
         NSDictionary *dict=@{@"authData":@{platform:authDataResult}};
-        [[LCHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
+        [[AVSNSHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
             if (!error) {
                 [AVOSCloudSNSUtils copyDictionary:object toObject:self];
                 [self setObject:dict[@"authData"] forKey:@"authData"];
@@ -220,7 +220,7 @@ NSString *const AVOSCloudSNSPlatformWeiXin = @"weixin";
                                  }};
     
     
-    [[LCHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
+    [[AVSNSHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
         
         AVUser * user = nil;
         if (error == nil)
@@ -254,7 +254,7 @@ NSString *const AVOSCloudSNSPlatformWeiXin = @"weixin";
         return;
     }
     NSDictionary *dict=@{@"authData":@{platform:authDataResult}};
-    [[LCHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
+    [[AVSNSHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
         AVUser * user = nil;
         if (!error) {
             user = [self user];

--- a/LeanCloudSocialDemo/LeanCloudSocialDemo.xcodeproj/project.pbxproj
+++ b/LeanCloudSocialDemo/LeanCloudSocialDemo.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = LeanCloudSocialDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -443,6 +444,7 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 				);
 				INFOPLIST_FILE = LeanCloudSocialDemo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/LeanCloudSocialDemo/Podfile
+++ b/LeanCloudSocialDemo/Podfile
@@ -6,7 +6,7 @@ workspace 'LeanCloudSocialDemo.xcworkspace'
 target 'LeanCloudSocial' do
     xcodeproj '../LeanCloudSocial.xcodeproj'
     pod 'AVOSCloud', '~> 3.1'
-    pod 'AFNetworking', '~> 1.0'
+    pod 'AFNetworking', '~> 2.0'
 end
 
 target 'LeanCloudSocialTests' do

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ xcodebuild -target UniversalFramework -config Release
 我可以使用其他 SDK 来做登录，然后把授权信息绑定到 AVUser 吗？
 
 ## ChangeLog
+发布流程：更改 podspec 版本，打 tag，推送到仓库，执行 pod trunk。
+
 0.0.2
 使用 AFNetworking ~2.0 版本，使得主项目能够和此库共用同一个 AFNetworking 版本。如果主项目使用的是 AFNetworking 1.0，推荐使用 LeanCloudSocial 0.0.1 版本。
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ xcodebuild -target UniversalFramework -config Release
 
 
 ## 其他问题
-### 我要增加其他平台，该怎么做？
+我要增加其他平台，该怎么做？
 
-### 我可以使用其他 SDK 来做登录，然后把授权信息绑定到 AVUser 吗？
+我可以使用其他 SDK 来做登录，然后把授权信息绑定到 AVUser 吗？
+
+## ChangeLog
+0.0.2
+使用 AFNetworking ~2.0 版本，使得主项目能够和此库共用同一个 AFNetworking 版本。如果主项目使用的是 AFNetworking 1.0，推荐使用 LeanCloudSocial 0.0.1 版本。
+
+0.0.1
+重命名模块后发布

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ xcodebuild -target UniversalFramework -config Release
 我可以使用其他 SDK 来做登录，然后把授权信息绑定到 AVUser 吗？
 
 ## ChangeLog
-发布流程：更改 podspec 版本，打 tag，推送到仓库，执行 pod trunk。
+发布流程：更改 podspec 版本，打 tag，推送到仓库，执行`pod trunk push LeanCloudSocial.podspec --verbose --allow-warnings --use-libraries`。
 
 0.0.3
 重命名 LCHttpClient 至 AVSNSHttpClient，避免和其它LC的模块冲突

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ xcodebuild -target UniversalFramework -config Release
 ## ChangeLog
 发布流程：更改 podspec 版本，打 tag，推送到仓库，执行 pod trunk。
 
+0.0.3
+重命名 LCHttpClient 至 AVSNSHttpClient，避免和其它LC的模块冲突
+
 0.0.2
 使用 AFNetworking ~2.0 版本，使得主项目能够和此库共用同一个 AFNetworking 版本。如果主项目使用的是 AFNetworking 1.0，推荐使用 LeanCloudSocial 0.0.1 版本。
 


### PR DESCRIPTION
前者考虑到现在大家用的是 AFNetworking 2.0以上的版本。13年9月发布的。我们的实现是用了 1.0，AFNetworking 的API 有不少改动，参考它的升级指南更换了上来。第三方登录都测试了一遍，没有问题。剩一个分享到微博还没测试。分享到微博应该是当时做微转的时候，特定加上的功能。等过会 LeanChat 加上再测试一下。改动也不是很大，所以暂时放着。
升级的原因是用pod 的时候，如果子库和主项目都用到了同一个库，需要根据两边的条件，得到一个两边都满足的版本，所以把这个social改为 '~> 2.0' ，就能兼容主项目的AFNetworking。


重命名是用户反馈也用了 LCHttpClient，LeanChat 用两个模块的话就会报错。赶现在趁早先重命名了。

@tang3w 