### PR TITLE
添加微信 SSO 登录

### DIFF
--- a/LeanCloudSocial.podspec
+++ b/LeanCloudSocial.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "LeanCloudSocial"
-  s.version      = "0.0.3"
+  s.version      = "0.0.4"
   s.summary      = "LeanCloud iOS Social SDK for mobile backend."
   s.homepage     = "https://leancloud.cn"
   s.license        = { :type => "Commercial", :text => "© Copyright 2015 LeanCloud, Inc. See https://leancloud.cn/terms.html" }

--- a/LeanCloudSocial/AVOSCloudSNS.h
+++ b/LeanCloudSocial/AVOSCloudSNS.h
@@ -97,7 +97,7 @@ typedef void (^AVSNSProgressBlock)(float percent);
  *  @param type 支持 QQ、WeiXin、Weibo
  *  @return
  */
-+ (BOOL)isApplicationInstalledForType:(AVOSCloudSNSType)type;
++ (BOOL)isAppInstalledForType:(AVOSCloudSNSType)type;
 
 /**
  *  用社交平台登录, 并获取手动显示登录界面

--- a/LeanCloudSocial/AVOSCloudSNS.h
+++ b/LeanCloudSocial/AVOSCloudSNS.h
@@ -27,6 +27,8 @@ typedef NS_ENUM(int, AVOSCloudSNSType){
     /// QQ
     AVOSCloudSNSQQ         =2,
     
+    /// 微信
+    AVOSCloudSNSWeiXin      =3,
 } ;
 
 #import "AVUser+SNS.h"
@@ -48,6 +50,11 @@ typedef NS_ENUM(int, AVOSCloudSNSErrorCode){
     /// Token过期
     AVOSCloudSNSErrorTokenExpired=4,
     
+    /// 操作不支持。当微信没有安装时，调用 -[loginWithCallback:platform] 会返回该错误，暂不支持微信网页登录
+    AVOSCloudSNSErrorCodeNotSupported = 5,
+    
+    /// 无效的第三方数据
+    AVOSCloudSNSErrorCodeAuthDataError = 6,
 };
 
 #import "AVUser+SNS.h"
@@ -84,6 +91,13 @@ typedef void (^AVSNSProgressBlock)(float percent);
  */
 +(void)setupPlatform:(AVOSCloudSNSType)type
           withAppKey:(NSString*)appkey andAppSecret:(NSString*)appsec andRedirectURI:(NSString*)redirect_uri;
+
+/**
+ *  相应的 App 是否有安装，如果有安装的话，说明可以用 SSO 跳转登录。没有安装的话，QQ 和微博将跳转至网页登录，微信暂时不支持网页登录，请隐藏微信按钮。
+ *  @param type 支持 QQ、WeiXin、Weibo
+ *  @return
+ */
++ (BOOL)isAppInstalledWithType:(AVOSCloudSNSType)type;
 
 /**
  *  用社交平台登录, 并获取手动显示登录界面

--- a/LeanCloudSocial/AVOSCloudSNS.h
+++ b/LeanCloudSocial/AVOSCloudSNS.h
@@ -97,7 +97,7 @@ typedef void (^AVSNSProgressBlock)(float percent);
  *  @param type 支持 QQ、WeiXin、Weibo
  *  @return
  */
-+ (BOOL)isAppInstalledWithType:(AVOSCloudSNSType)type;
++ (BOOL)isApplicationInstalledForType:(AVOSCloudSNSType)type;
 
 /**
  *  用社交平台登录, 并获取手动显示登录界面

--- a/LeanCloudSocial/AVOSCloudSNS.m
+++ b/LeanCloudSocial/AVOSCloudSNS.m
@@ -262,7 +262,7 @@ NSString * const AVOSCloudSNSErrorDomain = @"com.avoscloud.snslogin";
     return prefix;
 }
 
-+ (BOOL)isAppInstalledWithType:(AVOSCloudSNSType)type {
++ (BOOL)isApplicationInstalledForType:(AVOSCloudSNSType)type {
     NSString *prefix;
     switch (type) {
         case AVOSCloudSNSQQ:

--- a/LeanCloudSocial/AVOSCloudSNS.m
+++ b/LeanCloudSocial/AVOSCloudSNS.m
@@ -33,9 +33,11 @@ NSString * const AVOSCloudSNSErrorDomain = @"com.avoscloud.snslogin";
 + (AFHTTPRequestOperationManager *)jsonRequestManager {
     static AFHTTPRequestOperationManager *jsonRequestManager;
     @synchronized (self) {
-        jsonRequestManager = [AFHTTPRequestOperationManager manager];
-        // 避免服务器不规范，没有返回 application/json
-        jsonRequestManager.responseSerializer.acceptableContentTypes = [jsonRequestManager.responseSerializer.acceptableContentTypes setByAddingObject:@"text/plain"];
+        if (!jsonRequestManager) {
+            jsonRequestManager = [AFHTTPRequestOperationManager manager];
+            // 避免服务器不规范，没有返回 application/json
+            jsonRequestManager.responseSerializer.acceptableContentTypes = [jsonRequestManager.responseSerializer.acceptableContentTypes setByAddingObject:@"text/plain"];
+        }
     }
     return jsonRequestManager;
 }

--- a/LeanCloudSocial/AVOSCloudSNS.m
+++ b/LeanCloudSocial/AVOSCloudSNS.m
@@ -577,7 +577,7 @@ NSString * const AVOSCloudSNSErrorDomain = @"com.avoscloud.snslogin";
             }
         }
     }else if ([scheme hasPrefix:@"wx"]){
-        if ([url.absoluteString rangeOfString:@"://oauth"].location != NSNotFound) {
+        if (params) {
             NSLog(@"wexin : %@", params);
             NSString *code = params[@"code"];
             if (code) {
@@ -592,14 +592,19 @@ NSString * const AVOSCloudSNSErrorDomain = @"com.avoscloud.snslogin";
                         [self onSuccess:AVOSCloudSNSWeiXin withToken:accessToken andExpires:expires andUid:openId];
                     }
                 }];
-            } else {
-                //用户取消授权 ?
             }
+        } else {
+            //用户取消授权 ?
+            [self onFail:AVOSCloudSNSWeiXin withError:[self errorWithCode:AVOSCloudSNSErrorUserCancel text:@"用户取消了授权"]];
         }
     } else {
         return NO;
     }
     return YES;
+}
+
++ (NSError *)errorWithCode:(NSInteger)code text:(NSString *)text {
+    return [NSError errorWithDomain:AVOSCloudSNSErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey:text}];
 }
 
 + (void)getWeixinAccessTokenByCode:(NSString *)code block:(AVSNSResultBlock)block{

--- a/LeanCloudSocial/AVOSCloudSNS.m
+++ b/LeanCloudSocial/AVOSCloudSNS.m
@@ -262,7 +262,7 @@ NSString * const AVOSCloudSNSErrorDomain = @"com.avoscloud.snslogin";
     return prefix;
 }
 
-+ (BOOL)isApplicationInstalledForType:(AVOSCloudSNSType)type {
++ (BOOL)isAppInstalledForType:(AVOSCloudSNSType)type {
     NSString *prefix;
     switch (type) {
         case AVOSCloudSNSQQ:

--- a/LeanCloudSocial/AVUser+SNS.m
+++ b/LeanCloudSocial/AVUser+SNS.m
@@ -257,7 +257,7 @@ NSString *const AVOSCloudSNSPlatformWeiXin = @"weixin";
     [[AVSNSHttpClient sharedInstance] postObject:@"users" withParameters:dict block:^(id object, NSError *error) {
         AVUser * user = nil;
         if (!error) {
-            // 第一次会返回
+//            第一次会返回
 //            objectId = 55b8b76400b066e34529d4a6;
 //            sessionToken = fzs03y5g7hr4r22iikhv2babe;
 //            createdAt = "2015-07-29T11:33:03.642Z";

--- a/LeanCloudSocialDemo/LeanCloudSocialDemo/AppDelegate.m
+++ b/LeanCloudSocialDemo/LeanCloudSocialDemo/AppDelegate.m
@@ -25,9 +25,6 @@
     NSLog(@"setAppId:%@, appKey:%@", appId, appKey);
     [AVOSCloud setAllLogsEnabled:YES];
     [AVOSCloud setLastModifyEnabled:YES];
-    
-    [AVOSCloudSNS setupPlatform:AVOSCloudSNSSinaWeibo withAppKey:@"2548122881" andAppSecret:@"ba37a6eb3018590b0d75da733c4998f8" andRedirectURI:@"http://wanpaiapp.com/oauth/callback/sina"];
-    [AVOSCloudSNS setupPlatform:AVOSCloudSNSQQ withAppKey:@"100512940" andAppSecret:@"afbfdff94b95a2fb8fe58a8e24c4ba5f" andRedirectURI:nil];
     return YES;
 }
 

--- a/LeanCloudSocialDemo/LeanCloudSocialDemo/Info.plist
+++ b/LeanCloudSocialDemo/LeanCloudSocialDemo/Info.plist
@@ -40,6 +40,16 @@
 				<string>tencent100512940</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>weixin</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>wxa3eacc1c86a717bc</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>1.0.0</string>

--- a/LeanCloudSocialDemo/LeanCloudSocialDemo/ViewController.m
+++ b/LeanCloudSocialDemo/LeanCloudSocialDemo/ViewController.m
@@ -93,7 +93,7 @@
 }
 
 - (IBAction)weixinLogin:(id)sender {
-    if ([AVOSCloudSNS isAppInstalledWithType:AVOSCloudSNSWeiXin]) {
+    if ([AVOSCloudSNS isApplicationInstalledForType:AVOSCloudSNSWeiXin]) {
         // 请到真机测试
         [AVOSCloudSNS loginWithCallback:^(id object, NSError *error) {
             //        {

--- a/LeanCloudSocialDemo/LeanCloudSocialDemo/ViewController.m
+++ b/LeanCloudSocialDemo/LeanCloudSocialDemo/ViewController.m
@@ -93,7 +93,7 @@
 }
 
 - (IBAction)weixinLogin:(id)sender {
-    if ([AVOSCloudSNS isApplicationInstalledForType:AVOSCloudSNSWeiXin]) {
+    if ([AVOSCloudSNS isAppInstalledForType:AVOSCloudSNSWeiXin]) {
         // 请到真机测试
         [AVOSCloudSNS loginWithCallback:^(id object, NSError *error) {
             //        {

--- a/LeanCloudSocialDemo/LeanCloudSocialDemo/ViewController.m
+++ b/LeanCloudSocialDemo/LeanCloudSocialDemo/ViewController.m
@@ -20,6 +20,7 @@
     [super viewDidLoad];
     [AVOSCloudSNS setupPlatform:AVOSCloudSNSSinaWeibo withAppKey:@"2548122881" andAppSecret:@"ba37a6eb3018590b0d75da733c4998f8" andRedirectURI:@"http://wanpaiapp.com/oauth/callback/sina"];
     [AVOSCloudSNS setupPlatform:AVOSCloudSNSQQ withAppKey:@"100512940" andAppSecret:@"afbfdff94b95a2fb8fe58a8e24c4ba5f" andRedirectURI:nil];
+    [AVOSCloudSNS setupPlatform:AVOSCloudSNSWeiXin withAppKey:@"wxa3eacc1c86a717bc" andAppSecret:@"b5bf245970b2a451fb8cebf8a6dff0c1" andRedirectURI:nil];
 }
 
 - (void)didReceiveMemoryWarning {
@@ -34,7 +35,7 @@
             NSLog(@"failed to get authentication from weibo. error: %@", error.description);
         } else {
             [AVUser loginWithAuthData:object platform:AVOSCloudSNSPlatformWeiBo block:^(AVUser *user, NSError *error) {
-                if ([self filerError:error]) {
+                if ([self filterError:error]) {
                     [self loginSucceedWithUser:user authData:object];
                 }
             }];
@@ -47,9 +48,9 @@
     //管理台生成网页url，来跳转至第三方登录的地址
     [AVOSCloudSNS loginWithURL:[NSURL URLWithString:@"https://leancloud.cn/1.1/sns/goto/vdhgf2lq96udqd73"] callback:^(id object, NSError *error) {
         NSLog(@"object : %@, error : %@", object, error);
-        if ([self filerError:error]) {
+        if ([self filterError:error]) {
             [AVUser loginWithAuthData:object platform:AVOSCloudSNSPlatformWeiBo block:^(AVUser *user, NSError *error) {
-                if ([self filerError:error]) {
+                if ([self filterError:error]) {
                     [self loginSucceedWithUser:user authData:object];
                 }
             }];
@@ -64,7 +65,7 @@
             NSLog(@"failed to get authentication from weibo. error: %@", error.description);
         } else {
             [AVUser loginWithAuthData:object platform:AVOSCloudSNSPlatformQQ block:^(AVUser *user, NSError *error) {
-                if ([self filerError:error]) {
+                if ([self filterError:error]) {
                     [self loginSucceedWithUser:user authData:object];
                 }
             }];
@@ -76,14 +77,14 @@
     // 这个需要到后台填写 应用 id 和 secret key
     [AVOSCloudSNS loginWithURL:[NSURL URLWithString:@"https://leancloud.cn/1.1/sns/goto/36wvmahsj3davi90"] callback:^(id object, NSError *error) {
         NSLog(@"object : %@ error: %@", object, error);
-        if ([self filerError:error]) {
+        if ([self filterError:error]) {
             // clean authData;
             NSMutableDictionary *authData = [NSMutableDictionary dictionary];
             [authData setObject:[object objectForKey:@"openid"] forKey:@"openid"];
             [authData setObject:[object objectForKey:@"expires_in"] forKey:@"expires_in"];
             [authData setObject:[object objectForKey:@"access_token"] forKey:@"access_token"];
             [AVUser loginWithAuthData:authData platform:AVOSCloudSNSPlatformQQ block:^(AVUser *user, NSError *error) {
-                if ([self filerError:error]) {
+                if ([self filterError:error]) {
                     [self loginSucceedWithUser:user authData:authData];
                 }
             }];
@@ -92,15 +93,49 @@
 }
 
 - (IBAction)weixinLogin:(id)sender {
-    // 需要自己去下载微信的 sdk，获得 authData，之后用 +[AVUser loginWithAuthData:block] 来登录
-    UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"注意" message:@"本 Demo 尚未实现微信账号登录，请你自己申请微信开放平台账号，并导入。" delegate:nil cancelButtonTitle:@"知道了" otherButtonTitles:nil, nil];
-    [alert show];
+    if ([AVOSCloudSNS isAppInstalledWithType:AVOSCloudSNSWeiXin]) {
+        // 请到真机测试
+        [AVOSCloudSNS loginWithCallback:^(id object, NSError *error) {
+            //        {
+            //            "access_token" = "OezXcEiiBSKSxW0eoylIeN_WWsgxroiydYCNnIX5hyDjK3CwA1hc2bvS1oaaaYqwpP7_vb7nhWadkCXGQukQ0hVjCPvWDHjGqSAF0utf2xvXG5coBh2RZViBKxd0POkMDYu0vNLQoBOTfl9yDzzLJQ";
+            //            avatar = "http://wx.qlogo.cn/mmopen/3Qx7ibib84ibZMVgJAaEAN7HW8Kyc3s0hLTKcuSlzSJibG8Mbr4g3PsApj8G1u5XxLq9Dnp7XiafxL9h4RSCUIbX39l6lc90Kyzcx/0";
+            //            "expires_at" = "2015-07-30 08:38:24 +0000";
+            //            id = oazTlwQwmWLyzz7wxnAXDsSZUjcM;
+            //            platform = 3;
+            //            "raw-user" =     {
+            //                city = "";
+            //                country = CN;
+            //                headimgurl = "http://wx.qlogo.cn/mmopen/3Qx7ibib84ibZMVgJAaEAN7HW8Kyc3s0hLTKcuSlzSJibG8Mbr4g3PsApj8G1u5XxLq9Dnp7XiafxL9h4RSCUIbX39l6lc90Kyzcx/0";
+            //                language = "zh_CN";
+            //                nickname = "\U674e\U667a\U7ef4";
+            //                openid = oazTlwQwmWLyzz7wxnAXDsSZUjcM;
+            //                privilege =         (
+            //                );
+            //                province = Beijing;
+            //                sex = 1;
+            //                unionid = ox7NLs813rA9sP6QPbadkulxgHn8;
+            //            };
+            //            username = "\U674e\U667a\U7ef4";
+            //        }
+            
+            NSLog(@"object : %@ error:%@", object, error);
+            if ([self filterError:error]) {
+                [AVUser loginWithAuthData:object platform:AVOSCloudSNSPlatformWeiXin block:^(AVUser *user, NSError *error) {
+                    if ([self filterError:error]) {
+                        [self loginSucceedWithUser:user authData:object];
+                    }
+                }];
+            }
+        } toPlatform:AVOSCloudSNSWeiXin];
+    } else {
+        [self alert:@"没有安装微信，暂不能登录"];
+    }
 }
 
 - (IBAction)wechatLogin:(id)sender {
-    [AVOSCloudSNS loginWithURL:[NSURL URLWithString:@"https://leancloud.cn/1.1/sns/goto/1t261wmvqzthpx0y"] callback:^(id object, NSError *error) {
-        NSLog(@"object : %@ error: %@", object, error);
-    }];
+//    [AVOSCloudSNS loginWithURL:[NSURL URLWithString:@"https://leancloud.cn/1.1/sns/goto/1t261wmvqzthpx0y"] callback:^(id object, NSError *error) {
+//        NSLog(@"object : %@ error: %@", object, error);
+//    }];
 }
 
 - (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
@@ -120,7 +155,7 @@
     [alert show];
 }
 
-- (BOOL)filerError:(NSError *)error {
+- (BOOL)filterError:(NSError *)error {
     if (error) {
         [self alert:[error localizedDescription]];
         return NO;

--- a/LeanCloudSocialDemo/LeanCloudSocialDemo/ViewController.m
+++ b/LeanCloudSocialDemo/LeanCloudSocialDemo/ViewController.m
@@ -18,6 +18,8 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    [AVOSCloudSNS setupPlatform:AVOSCloudSNSSinaWeibo withAppKey:@"2548122881" andAppSecret:@"ba37a6eb3018590b0d75da733c4998f8" andRedirectURI:@"http://wanpaiapp.com/oauth/callback/sina"];
+    [AVOSCloudSNS setupPlatform:AVOSCloudSNSQQ withAppKey:@"100512940" andAppSecret:@"afbfdff94b95a2fb8fe58a8e24c4ba5f" andRedirectURI:nil];
 }
 
 - (void)didReceiveMemoryWarning {

--- a/README.md
+++ b/README.md
@@ -64,14 +64,15 @@ xcodebuild -target UniversalFramework -config Release
 ## ChangeLog
 发布流程：更改 podspec 版本，打 tag，推送到仓库，执行`pod trunk push LeanCloudSocial.podspec --verbose --allow-warnings --use-libraries`。
 
-0.0.4
-支持微信 SSO 登录，对 -[AVOSCloudSNS loginWithCallback:toPlatform] 第二个参数传入 AVOSCloudSNSWeiXin 即可。同时提供 -[AVOSCloudSNS isAppInstalledWithType] 来检测相应的应用有没安装。
+0.0.4	
+支持微信 SSO 登录，对 -[AVOSCloudSNS loginWithCallback:toPlatform] 第二个参数传入 AVOSCloudSNSWeiXin 即可。
+同时提供 -[AVOSCloudSNS isAppInstalledWithType] 来检测相应的应用有没安装。
 
-0.0.3
+0.0.3	
 重命名 LCHttpClient 至 AVSNSHttpClient，避免和其它LC的模块冲突
 
-0.0.2
+0.0.2	
 使用 AFNetworking ~2.0 版本，使得主项目能够和此库共用同一个 AFNetworking 版本。如果主项目使用的是 AFNetworking 1.0，推荐使用 LeanCloudSocial 0.0.1 版本。
 
-0.0.1
+0.0.1	
 重命名模块后发布

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ xcodebuild -target UniversalFramework -config Release
 ## ChangeLog
 发布流程：更改 podspec 版本，打 tag，推送到仓库，执行`pod trunk push LeanCloudSocial.podspec --verbose --allow-warnings --use-libraries`。
 
+0.0.4
+支持微信 SSO 登录，对 -[AVOSCloudSNS loginWithCallback:toPlatform] 第二个参数传入 AVOSCloudSNSWeiXin 即可。同时提供 -[AVOSCloudSNS isAppInstalledWithType] 来检测相应的应用有没安装。
+
 0.0.3
 重命名 LCHttpClient 至 AVSNSHttpClient，避免和其它LC的模块冲突
 


### PR DESCRIPTION
我制作了一个视频，打开即可播放：

http://ac-x3o016bx.clouddn.com/a294809feb0c6a8a.mp4

从视频中可看到，其中做了一个处理，假如第三方的用户名在 LeanCloud 上有的话，就用了第三方用户名加三个随机的字符，作为用户名。不过这个都是 LeanChat 自己的逻辑了。

微信 SSO 登录，借鉴了 [openshare](https://github.com/100apps/openshare)，不需要使用微信官方的SDK 就能跳转去登录。:+1:

但如果微信没有安装的话，现在还不支持微信的网页登录。所以我提供了一个接口 -[AVOSCloudSNS isAppInstalledWithType] ，让开发者来判断给予提示或者隐藏按钮。以前 QQ和微博的实现是，先 SSO 跳转应用登录，不成功的话，跳转到网页登录(sdk 实现的网页登录)。因为网页登录还有点麻烦，暂时没支持微信的网页登录了。

如果开发者非要实现没有安装微信也要通过微信登录的话，我们建议他走我们的后台统一的webview登录，把appId 写在管理台，由服务器生成登录的网页，类似，https://leancloud.cn/1.1/sns/goto/36wvmahsj3davi90 

@tang3w 
