### PR TITLE
Fix empty framework

### DIFF
--- a/LeanCloudSocial.xcodeproj/project.pbxproj
+++ b/LeanCloudSocial.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		5CC5044D1B0EC5B9004D0CB1 /* LeanCloudSocial.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CC504411B0EC5B8004D0CB1 /* LeanCloudSocial.framework */; };
 		5CC504541B0EC5B9004D0CB1 /* LeanCloudSocialTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5CC504531B0EC5B9004D0CB1 /* LeanCloudSocialTests.m */; };
 		70A6A15D1B661BA6005C2D21 /* AVOSCloudSNS_.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A6A14C1B661BA6005C2D21 /* AVOSCloudSNS_.h */; };
-		70A6A15E1B661BA6005C2D21 /* AVOSCloudSNS.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A6A14D1B661BA6005C2D21 /* AVOSCloudSNS.h */; };
+		70A6A15E1B661BA6005C2D21 /* AVOSCloudSNS.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A6A14D1B661BA6005C2D21 /* AVOSCloudSNS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		70A6A15F1B661BA6005C2D21 /* AVOSCloudSNS.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A6A14E1B661BA6005C2D21 /* AVOSCloudSNS.m */; };
 		70A6A1601B661BA6005C2D21 /* AVOSCloudSNSUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A6A14F1B661BA6005C2D21 /* AVOSCloudSNSUtils.h */; };
 		70A6A1611B661BA6005C2D21 /* AVOSCloudSNSUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 70A6A1501B661BA6005C2D21 /* AVOSCloudSNSUtils.m */; };
@@ -195,9 +195,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				70A6A15E1B661BA6005C2D21 /* AVOSCloudSNS.h in Headers */,
 				70A6A1641B661BA6005C2D21 /* AVSNSWebViewController.h in Headers */,
 				70A6A16C1B661BA6005C2D21 /* NSURL+AVAdditions.h in Headers */,
-				70A6A15E1B661BA6005C2D21 /* AVOSCloudSNS.h in Headers */,
 				70A6A16A1B661BA6005C2D21 /* AVSNSHttpClient.h in Headers */,
 				70A6A1681B661BA6005C2D21 /* AVWebViewController.h in Headers */,
 				70A6A1601B661BA6005C2D21 /* AVOSCloudSNSUtils.h in Headers */,
@@ -486,11 +486,9 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = LeanCloudSocial/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -508,11 +506,9 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = LeanCloudSocial/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/LeanCloudSocialDemo/LeanCloudSocialDemo/Info.plist
+++ b/LeanCloudSocialDemo/LeanCloudSocialDemo/Info.plist
@@ -69,5 +69,58 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+        <!-- QQ、Qzone URL Scheme 白名单-->
+        <string>mqqOpensdkSSoLogin</string>
+        
+        <!-- 微信 URL Scheme 白名单-->
+        <string>weixin</string>
+        
+        <!-- 新浪微博 URL Scheme 白名单-->
+        <string>sinaweibohdsso</string>
+        <string>sinaweibosso</string>
+    </array>
+    
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+            
+            <!-- 集成新浪微博对应的HTTP白名单-->
+            <key>weibo.cn</key>
+            <dict>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+                <false/>
+            </dict>
+            <key>weibo.com</key>
+            <dict>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+                <false/>
+            </dict>
+            <!-- 新浪微博-->
+            
+            <!-- 集成微信、QQ、Qzone、腾讯微博授权对应的HTTP白名单-->
+            <key>qq.com</key>
+            <dict>
+                <key>NSIncludesSubdomains</key>
+                <true/>
+                <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+                <key>NSThirdPartyExceptionRequiresForwardSecrecy</key>
+                <false/>
+            </dict>
+            <!-- 腾讯授权-->
+            
+        </dict>
+    </dict>
+
 </dict>
 </plist>

--- a/LeanCloudSocialDemo/Podfile
+++ b/LeanCloudSocialDemo/Podfile
@@ -5,7 +5,7 @@ workspace 'LeanCloudSocialDemo.xcworkspace'
 
 target 'LeanCloudSocial' do
     xcodeproj '../LeanCloudSocial.xcodeproj'
-    pod 'AVOSCloud', '~> 3.1'
+    pod 'AVOSCloud', '~> 3.1.4'
     pod 'AFNetworking', '~> 2.0'
 end
 
@@ -22,4 +22,3 @@ end
 target 'LeanCloudSocialDemoTests' do
     xcodeproj 'LeanCloudSocialDemo.xcodeproj'
 end
-


### PR DESCRIPTION
Close https://github.com/leancloud/leancloud-social-ios/issues/13

设置如下：

![qq20150923-1 2x](https://cloud.githubusercontent.com/assets/5022872/10043463/e8efc660-6225-11e5-9eb0-46a54d03bda8.jpg)

这样在 archive 的时候就不会出现 Empty framework 的问题。很奇怪。应该是新版 Xcode 的  Bug。

skip install 的意思是不安装到系统中。不应该和这个问题有关联。

@tang3w 