### PR TITLE
Rename non-static symbols for afnetworking

### DIFF
--- a/Classes/Vendor/AFNetworking/LCSURLSessionManager.h
+++ b/Classes/Vendor/AFNetworking/LCSURLSessionManager.h
@@ -457,7 +457,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @deprecated Use `AFNetworkingTaskDidResumeNotification` instead.
  */
-FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidStartNotification DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString * const LCNetworkingTaskDidStartNotification DEPRECATED_ATTRIBUTE;
 
 /**
  Posted when a task resumes.
@@ -469,7 +469,7 @@ FOUNDATION_EXPORT NSString * const LCSNetworkingTaskDidResumeNotification;
 
  @deprecated Use `AFNetworkingTaskDidCompleteNotification` instead.
  */
-FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidFinishNotification DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString * const LCNetworkingTaskDidFinishNotification DEPRECATED_ATTRIBUTE;
 
 /**
  Posted when a task finishes executing. Includes a userInfo dictionary with additional information about the task.
@@ -496,7 +496,7 @@ FOUNDATION_EXPORT NSString * const LCSURLSessionDownloadTaskDidFailToMoveFileNot
 
  @deprecated Use `AFNetworkingTaskDidCompleteResponseDataKey` instead.
  */
-FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidFinishResponseDataKey DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString * const LCNetworkingTaskDidFinishResponseDataKey DEPRECATED_ATTRIBUTE;
 
 /**
  The raw response data of the task. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if response data exists for the task.
@@ -508,7 +508,7 @@ FOUNDATION_EXPORT NSString * const LCSNetworkingTaskDidCompleteResponseDataKey;
 
  @deprecated Use `AFNetworkingTaskDidCompleteSerializedResponseKey` instead.
  */
-FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidFinishSerializedResponseKey DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString * const LCNetworkingTaskDidFinishSerializedResponseKey DEPRECATED_ATTRIBUTE;
 
 /**
  The serialized response object of the task. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if the response was serialized.
@@ -520,7 +520,7 @@ FOUNDATION_EXPORT NSString * const LCSNetworkingTaskDidCompleteSerializedRespons
 
  @deprecated Use `AFNetworkingTaskDidCompleteResponseSerializerKey` instead.
  */
-FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidFinishResponseSerializerKey DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString * const LCNetworkingTaskDidFinishResponseSerializerKey DEPRECATED_ATTRIBUTE;
 
 /**
  The response serializer used to serialize the response. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if the task has an associated response serializer.
@@ -532,7 +532,7 @@ FOUNDATION_EXPORT NSString * const LCSNetworkingTaskDidCompleteResponseSerialize
 
  @deprecated Use `AFNetworkingTaskDidCompleteAssetPathKey` instead.
  */
-FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidFinishAssetPathKey DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString * const LCNetworkingTaskDidFinishAssetPathKey DEPRECATED_ATTRIBUTE;
 
 /**
  The file path associated with the download task. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if an the response data has been stored directly to disk.
@@ -544,7 +544,7 @@ FOUNDATION_EXPORT NSString * const LCSNetworkingTaskDidCompleteAssetPathKey;
 
  @deprecated Use `AFNetworkingTaskDidCompleteErrorKey` instead.
  */
-FOUNDATION_EXPORT NSString * const AFNetworkingTaskDidFinishErrorKey DEPRECATED_ATTRIBUTE;
+FOUNDATION_EXPORT NSString * const LCNetworkingTaskDidFinishErrorKey DEPRECATED_ATTRIBUTE;
 
 /**
  Any error associated with the task, or the serialization of the response. Included in the userInfo dictionary of the `AFNetworkingTaskDidFinishNotification` if an error exists.

--- a/Classes/Vendor/AFNetworking/LCSURLSessionManager.m
+++ b/Classes/Vendor/AFNetworking/LCSURLSessionManager.m
@@ -60,8 +60,8 @@ NSString * const LCSNetworkingTaskDidSuspendNotification = @"com.alamofire.netwo
 NSString * const LCSURLSessionDidInvalidateNotification = @"com.alamofire.networking.session.invalidate";
 NSString * const LCSURLSessionDownloadTaskDidFailToMoveFileNotification = @"com.alamofire.networking.session.download.file-manager-error";
 
-NSString * const AFNetworkingTaskDidStartNotification = @"com.alamofire.networking.task.resume"; // Deprecated
-NSString * const AFNetworkingTaskDidFinishNotification = @"com.alamofire.networking.task.complete"; // Deprecated
+NSString * const LCNetworkingTaskDidStartNotification = @"com.alamofire.networking.task.resume"; // Deprecated
+NSString * const LCNetworkingTaskDidFinishNotification = @"com.alamofire.networking.task.complete"; // Deprecated
 
 NSString * const LCSNetworkingTaskDidCompleteSerializedResponseKey = @"com.alamofire.networking.task.complete.serializedresponse";
 NSString * const LCSNetworkingTaskDidCompleteResponseSerializerKey = @"com.alamofire.networking.task.complete.responseserializer";
@@ -69,11 +69,11 @@ NSString * const LCSNetworkingTaskDidCompleteResponseDataKey = @"com.alamofire.n
 NSString * const LCSNetworkingTaskDidCompleteErrorKey = @"com.alamofire.networking.task.complete.error";
 NSString * const LCSNetworkingTaskDidCompleteAssetPathKey = @"com.alamofire.networking.task.complete.assetpath";
 
-NSString * const AFNetworkingTaskDidFinishSerializedResponseKey = @"com.alamofire.networking.task.complete.serializedresponse"; // Deprecated
-NSString * const AFNetworkingTaskDidFinishResponseSerializerKey = @"com.alamofire.networking.task.complete.responseserializer"; // Deprecated
-NSString * const AFNetworkingTaskDidFinishResponseDataKey = @"com.alamofire.networking.complete.finish.responsedata"; // Deprecated
-NSString * const AFNetworkingTaskDidFinishErrorKey = @"com.alamofire.networking.task.complete.error"; // Deprecated
-NSString * const AFNetworkingTaskDidFinishAssetPathKey = @"com.alamofire.networking.task.complete.assetpath"; // Deprecated
+NSString * const LCNetworkingTaskDidFinishSerializedResponseKey = @"com.alamofire.networking.task.complete.serializedresponse"; // Deprecated
+NSString * const LCNetworkingTaskDidFinishResponseSerializerKey = @"com.alamofire.networking.task.complete.responseserializer"; // Deprecated
+NSString * const LCNetworkingTaskDidFinishResponseDataKey = @"com.alamofire.networking.complete.finish.responsedata"; // Deprecated
+NSString * const LCNetworkingTaskDidFinishErrorKey = @"com.alamofire.networking.task.complete.error"; // Deprecated
+NSString * const LCNetworkingTaskDidFinishAssetPathKey = @"com.alamofire.networking.task.complete.assetpath"; // Deprecated
 
 static NSString * const AFURLSessionManagerLockName = @"com.alamofire.networking.session.manager.lock";
 


### PR DESCRIPTION
为 AFNetworking 重命名漏掉的一些 non-static 符号。