### PR TITLE
修复第三方登录 WebView 登录链接失效问题

### DIFF
--- a/Classes/AVSNSLoginViewController.m
+++ b/Classes/AVSNSLoginViewController.m
@@ -61,7 +61,7 @@ static NSString * const AVOS_SNS_API_VERSION=@"1";
     if (type==0) {
         //打开选择登录界面
         
-        NSString *url=[NSString stringWithFormat:@"https://%@/%@",AVOS_SNS_BASE_URL,@"sns.html"];
+        NSString *url=[NSString stringWithFormat:@"https://%@/%@",AVOS_SNS_BASE_URL2,@"sns.html"];
         
         [self.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
         return;


### PR DESCRIPTION
测试第三方登录时遇到的问题：

这四个方法都是登录入口方法：
+loginWithCallback:
+loginWithCallback: toPlatform:
+loginManuallyWithCallback：
+loginManuallyWithCallback：toPlatform:

其中两个带 toPlatform 参数的方法传了AVOSCloudSNSType，是没有问题的。
另外两个不带 toPlatform 参数的方法没有传AVOSCloudSNSType，也就是下面 type==0：
```
  if (type==0) {
        //打开选择登录界面
        
        NSString *url=[NSString stringWithFormat:@"https://%@/%@",AVOS_SNS_BASE_URL,@"sns.html"];
        
        [self.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:url]]];
        return;
    }
```
上面的 url 是有问题：https://cn.avoscloud.com/sns.html ===》404
运行效果：
![sns_ios](https://user-images.githubusercontent.com/11917002/33070289-7fcc7b24-cef2-11e7-8014-2f4d89d999a5.png)

url 改为 AVOS_SNS_BASE_URL2  即 https://leancloud.cn/sns.html 就好了。


已经测试过，修改后 url 后无论是 SSO 登录，还是 webView 授权登录，这两个方法都可以正常登录了。
